### PR TITLE
Overhaul zapp to use toolchains

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -32,3 +32,7 @@ git_repository(
     remote = "https://github.com/bazelbuild/rules_python.git",
     tag = "0.3.0",
 )
+
+register_toolchains(
+    "//zapp:zappc_toolchain",
+)

--- a/example/WORKSPACE
+++ b/example/WORKSPACE
@@ -31,6 +31,16 @@ git_repository(
 
 register_toolchains("//:python3_toolchain")
 
+load("@rules_python//python:pip.bzl", "pip_install")
+
+pip_install(
+    name = "my_deps",
+    requirements = "//:requirements.txt",
+)
+
+####################################################################################################
+# rules_zapp
+####################################################################################################
 # git_repository(
 #     name = "rules_zapp",
 #     remote = "https://github.com/arrdem/rules_zapp.git",
@@ -43,9 +53,6 @@ local_repository(
     path = "../",
 )
 
-load("@rules_python//python:pip.bzl", "pip_install")
-
-pip_install(
-    name = "my_deps",
-    requirements = "//:requirements.txt",
+register_toolchains(
+    "@rules_zapp//zapp:zappc_toolchain",
 )

--- a/zapp/BUILD
+++ b/zapp/BUILD
@@ -1,6 +1,9 @@
 package(default_visibility = ["//visibility:public"])
 
-load("zapp.bzl", "zapp_binary")
+load("zapp.bzl",
+     "zapp_binary",
+     "zapp_toolchain"
+)
 
 # Zapp plugins used as a runtime library by rules_zapp
 py_library(
@@ -13,7 +16,7 @@ py_library(
 
 # Bootstrapping Zapp using py_binary
 py_binary(
-    name = "zappc",
+    name = "bootstrap_zappc",
     main = "compiler/__main__.py",
     srcs = glob(["support/**/*.py"]) + [
       "compiler/__main__.py"
@@ -23,9 +26,22 @@ py_binary(
     ],
 )
 
-# For testing of zappc
+toolchain_type(name = "toolchain_type")
+
+zapp_toolchain(
+    name = "zappc_info",
+    compiler = ":bootstrap_zappc",
+)
+
+toolchain(
+    name = "zappc_toolchain",
+    toolchain = ":zappc_info",
+    toolchain_type = ":toolchain_type",
+)
+
+# Now we can zapp zapp itself...
 zapp_binary(
-    name = "zappzappc",
+    name = "zappc",
     main = "compiler/__main__.py",
     srcs = glob(["support/**/*.py"]) + [
       "compiler/__main__.py"


### PR DESCRIPTION
Following on the heels of #2 which enabled Zapp! to read the python interpreter from the appropriate toolchain, this patch attempts to make `zappc` itself toolchain-resident and something a user can control. This would supersede the existing `compiler=` label parameter.

Hypothetically, this would allow for the current `py_binary` zappc to be demoted to a bootstrap artifact, and for what is currently `zappzappc` to be promoted to the "production" zappc, not that it buys us anything.